### PR TITLE
State change refresh on tweets that was missing from previous RC

### DIFF
--- a/Twitter Client/Twitter Client/AppDelegate.swift
+++ b/Twitter Client/Twitter Client/AppDelegate.swift
@@ -49,6 +49,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func applicationDidBecomeActive(application: UIApplication) {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+        dataSource.fetchNewItems { 
+            self.dataSource.delegate?.tweetItemsDidChange()
+        }
     }
 
     func applicationWillTerminate(application: UIApplication) {


### PR DESCRIPTION
Adding back the applicationDidBecomeActive requirement of loading new tweets. 
